### PR TITLE
remove mentor from Mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ in the [TAC Charter][].
     * [JerryScript][]
       * Dave Methvin
     * [Mocha][]
-      * Adam Ulvi
+      * (vacant)
     * [Moment][]
       * Anne-Gaelle Colom
     * [Node-RED][]


### PR DESCRIPTION
Adam hasn't been active for a couple years due to work/life etc.